### PR TITLE
Avoid Uncaught expection if hll is undefined

### DIFF
--- a/src/hll.js
+++ b/src/hll.js
@@ -176,7 +176,7 @@
  * see {@link https://github.com/aggregateknowledge/hll-storage-spec here}.
  */
 
-if(hll === undefined)
+if(typeof hll === "undefined")
     var hll = { version: "1.0.0" };
 (function () {
     // ** Config ***************************************************************

--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,7 @@
  * </ul>
  */
 
-if(hll === undefined)
+if(typeof hll === "undefined")
     var hll = { version: "1.0.0" };
 if(hll.util === undefined)
     hll.util = { version: "1.0.0" };


### PR DESCRIPTION
If `hll` is undefined, it throws an error. Using `typeof` solves this.